### PR TITLE
Fix misspelled fieldsRules example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const MyFunction = () => {
   const [name, setName] = useState('');
   
   const { isFieldInError, getErrorsInField, isFormValid } = useValidation({
-    fieldRules: {
+    fieldsRules: {
       email: { email: true },
       name: { required: true }
     },


### PR DESCRIPTION
useValidation expects an object with a field called fieldsRules not fieldRules